### PR TITLE
[ENGOPS-1501] Add a new parameter for labels you need "at least one"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # IDE nonsense
 *~
+test.sh


### PR DESCRIPTION
`-y/--require-labels` is a logical AND between labels; anything provided here, the PR has to have ALL of these labels.

`-1/--at-least-one-label` is a logical OR between labels; anything provided here, the PR has to have AT LEAST ONE of them.

So by specifying e.g. `-1 "ready,qa" -y ""` we can merge anything that is _either_ `ready` _or_ `qa`.