### PR TITLE
ENGOPS-1553 Retry if UNKNOWN PRs exceed threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ This generates a list of branches who have PRs that pass a number of criteria:
 | N         | -n, --reject-labels      | Ignore any PRs with this array of tags; use "" to clear             | `hold`         |
 | N         | -y, --require-labels     | Require PRs to have these tags                                      | `ready`        |
 | N         | -1, --at-least-one-label | At least one of these tags is required                              | `[]`           |
-| N         | -u, --unknown-threshold  | Number expressing a percent of UNKNOWN state PRs to trigger a retry | `10` [percent] |
-| N         | -r, --retry-delay        | Time in seconds before retrying when UNKNOWN PRs exceed threshold   | `30` (seconds) |
+| N         | -u, --unknown-threshold  | Number expressing a percent of UNKNOWN state PRs to trigger a retry | `1`  [percent] |
+| N         | -r, --retry-delay        | Time in seconds before retrying when UNKNOWN PRs exceed threshold   | `30` [seconds] |
 | N         | -m, --max-retries        | Maximum number of retries before we give up completely              | `10`           |
 | N         | -d, --debug              | Debug log level                                                     | Warn           |
 | N         | -v, --verbose            | Info log level                                                      | Warn           |

--- a/README.md
+++ b/README.md
@@ -18,14 +18,18 @@ This generates a list of branches who have PRs that pass a number of criteria:
 
 # Options
 
-| Option               | Required? | Description                                             | default  |
-|----------------------|-----------|---------------------------------------------------------|----------|
-| -b, --base           | N         | target branch of PRs to search for                      | `master` |
-| -n, --reject-labels  | N         | Ignore any PRs with this array of tags; use "" to clear | `hold`   |
-| -y, --require-labels | N         | Require PRs to have these tags                          | `ready`  |
-| -1, --at-least-one-label | N     | At least one of these tags is required                  | `[]`     |
-| -d, --debug          | N         | Debug log level                                         | Warn     |
-| -v, --verbose        | N         | Info log level                                          | Warn     |
+| Required? | Option                   | Description                                                         | default        |
+|-----------|--------------------------|---------------------------------------------------------------------|----------------|
+| N         | -b, --base               | target branch of PRs to search for                                  | `master`       |
+| N         | -n, --reject-labels      | Ignore any PRs with this array of tags; use "" to clear             | `hold`         |
+| N         | -y, --require-labels     | Require PRs to have these tags                                      | `ready`        |
+| N         | -1, --at-least-one-label | At least one of these tags is required                              | `[]`           |
+| N         | -u, --unknown-threshold  | Number expressing a percent of UNKNOWN state PRs to trigger a retry | `10` [percent] |
+| N         | -r, --retry-delay        | Time in seconds before retrying when UNKNOWN PRs exceed threshold   | `30` (seconds) |
+| N         | -m, --max-retries        | Maximum number of retries before we give up completely              | `10`           |
+| N         | -d, --debug              | Debug log level                                                     | Warn           |
+| N         | -v, --verbose            | Info log level                                                      | Warn           |
+
 
 ## Note on options
 

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ inputs:
     required: true
     default: ''
   additional-args:
-    description: 'Additional args e.g. -d or -v'
+    description: 'Additional args e.g. -d or -v; see README'
     required: false
 outputs:
   branches:

--- a/select_prs.rb
+++ b/select_prs.rb
@@ -107,10 +107,10 @@ module GitHub
   end
 
   def self.percent
-    if @count == 0
+    if @count.zero?
       0
     else
-      100 * ( @unknowns / @count )
+      (100 * @unknowns) / @count
     end
   end
 

--- a/select_prs.rb
+++ b/select_prs.rb
@@ -108,9 +108,9 @@ module GitHub
 
   def self.percent
     if @count.zero?
-      0
+      0.0
     else
-      (100 * @unknowns) / @count
+      (100.0 * @unknowns) / @count
     end
   end
 

--- a/select_prs.rb
+++ b/select_prs.rb
@@ -249,7 +249,7 @@ opts = Slop.parse do |o|
   o.array '-y', '--require-labels', 'ALL of these labels are required to be in the PR. (default [\'ready\'])', default: ['ready']
   o.array '-n', '--reject-labels', 'Labels that rule out a PR (default [\'hold\'])', default: ['hold']
   o.array '-1', '--at-least-one-label', 'Require at least one of these labels (default [])', default: []
-  o.integer '-u', '--unknown-threshold', 'If the pecentage of UNKNOWN PRs exceed this, retry (default 10)', default: 10
+  o.integer '-u', '--unknown-threshold', 'If the pecentage of UNKNOWN PRs exceed this, retry (default 1)', default: 1
   o.integer '-r', '--retry-delay', 'How long to wait, in seconds, to retry (default 30)', default: 30
   o.integer '-m', '--max-retries', 'How many times to retry before the job failes (deafult 10)', default: 10
   o.on '-h', '--help' do

--- a/select_prs.rb
+++ b/select_prs.rb
@@ -244,5 +244,13 @@ GitHub.log_level(
 
 GitHub.logger.debug("Github Repository: #{ENV['GITHUB_REPOSITORY']}")
 
-branches = GitHub.branches_matching_filter(opts).join(' ')
+branches = nil
+loop do
+  GitHub.logger.info("Trying again... Try #{GitHub.tries + 1}") if GitHub.tries.positive?
+  branches = GitHub.branches_matching_filter(opts).join(' ')
+  GitHub.logger.debug("Percent: #{GitHub.percent}; Tries: #{GitHub.tries}")
+  break if (GitHub.tries >= opts[:max_retries]) || (GitHub.percent < opts[:unknown_threshold])
+end
+raise 'Giving up after too many failures' if GitHub.tries >= opts[:max_retries]
+
 puts "::set-output name=branches::#{branches}"

--- a/select_prs.rb
+++ b/select_prs.rb
@@ -97,14 +97,29 @@ module GitHub
     }
   GRAPHQL
 
-  @@logger = Logger.new($stdout)
+  @logger = Logger.new($stdout)
+  @count    = 0
+  @unknowns = 0
+  @tries  = 0
+
+  def self.tries
+    @tries
+  end
+
+  def self.percent
+    if @count == 0
+      0
+    else
+      100 * ( @unknowns / @count )
+    end
+  end
 
   def self.log_level(level)
-    @@logger.level = level
+    @logger.level = level
   end
-  
+
   def self.logger
-    @@logger
+    @logger
   end
 
   FirstQuery = Client.parse(PR_QUERY_TEMPLATE % '')
@@ -113,7 +128,7 @@ module GitHub
   def self.pr_filter(graphql_result, base, reject_labels, require_labels, at_least_one_label)
     filtered_pr_refs = []
     graphql_result.data.repository.pull_requests.edges.each do |pr|
-      @@logger.debug("Investigating #{pr.node.title} by #{pr.node.author.login}")
+      @logger.debug("Investigating #{pr.node.title} by #{pr.node.author.login}")
       next if     GitHub.pr_is_draft?(pr)
       next unless GitHub.pr_is_mergeable?(pr)
       next unless GitHub.pr_passed_tests?(pr)
@@ -124,7 +139,7 @@ module GitHub
       next unless GitHub.pr_has_all_required_labels?(pr, labels, require_labels)
       next unless GitHub.pr_has_at_least_one_label?(pr, labels, at_least_one_label)
 
-      @@logger.info("Appending #{pr.node.head_ref.name}")
+      @logger.info("Appending #{pr.node.head_ref.name}")
       filtered_pr_refs.append(pr.node.head_ref.name)
     end
     filtered_pr_refs
@@ -132,15 +147,19 @@ module GitHub
 
   def self.pr_is_draft?(pull_request)
     if pull_request.node.is_draft?
-      @@logger.info("-- Rejecting #{pull_request.node.head_ref.name}: PR is draft.")
+      @logger.info("-- Rejecting #{pull_request.node.head_ref.name}: PR is draft.")
       return true
     end
     false
   end
 
   def self.pr_is_mergeable?(pull_request)
+    @count += 1
+    @logger.debug("Count: #{@count}")
     if pull_request.node.mergeable != 'MERGEABLE'
-      @@logger.info("-- Rejecting #{pull_request.node.head_ref.name}: PR merge state is #{pull_request.node.mergeable}, not MERGEABLE.")
+      @logger.info("-- Rejecting #{pull_request.node.head_ref.name}: PR merge state is #{pull_request.node.mergeable}, not MERGEABLE.")
+      @unknowns += 1 if pull_request.node.mergeable == 'UNKNOWN'
+      @logger.debug("Unknowns: #{@unknowns}")
       return false
     end
     true
@@ -148,12 +167,12 @@ module GitHub
 
   def self.pr_passed_tests?(pull_request)
     if pull_request.node.commits.nodes[0].commit.status.nil?
-      @@logger.debug("++ Accepting #{pull_request.node.head_ref.name} despite lack of commit status")
+      @logger.debug("++ Accepting #{pull_request.node.head_ref.name} despite lack of commit status")
       return true
     end
     if pull_request.node.commits.nodes[0].commit.status.state != 'SUCCESS'
-      @@logger.info("-- Rejecting #{pull_request.node.head_ref.name}: ")
-      @@logger.info("   commit #{pull_request.node.commits.nodes[0].commit.oid} test state is #{pull_request.node.commits.nodes[0].commit.status.state}")
+      @logger.info("-- Rejecting #{pull_request.node.head_ref.name}: ")
+      @logger.info("   commit #{pull_request.node.commits.nodes[0].commit.oid} test state is #{pull_request.node.commits.nodes[0].commit.status.state}")
       return false
     end
     true
@@ -161,7 +180,7 @@ module GitHub
 
   def self.pr_against_base?(pull_request, base)
     if pull_request.node.base_ref_name != base
-      @@logger.info("-- Rejecting #{pull_request.node.head_ref.name}: PR's base #{pull_request.node.base_ref_name} is not #{base}")
+      @logger.info("-- Rejecting #{pull_request.node.head_ref.name}: PR's base #{pull_request.node.base_ref_name} is not #{base}")
       return false
     end
     true
@@ -169,9 +188,9 @@ module GitHub
 
   def self.pr_has_rejected_labels?(pull_request, pr_labels, reject_labels)
     if !reject_labels.empty? && (pr_labels & reject_labels != [])
-      @@logger.info("-- Rejecting #{pull_request.node.head_ref.name}: has a rejected label")
-      @@logger.info("   PR Labels: #{pr_labels.join(', ')}")
-      @@logger.info("   Reject labels: #{reject_labels.join(', ')}")
+      @logger.info("-- Rejecting #{pull_request.node.head_ref.name}: has a rejected label")
+      @logger.info("   PR Labels: #{pr_labels.join(', ')}")
+      @logger.info("   Reject labels: #{reject_labels.join(', ')}")
       return true
     end
     false
@@ -179,9 +198,9 @@ module GitHub
 
   def self.pr_has_all_required_labels?(pull_request, pr_labels, require_labels)
     if !require_labels.empty? && ((pr_labels & require_labels).sort != require_labels.sort)
-      @@logger.info("-- Rejecting #{pull_request.node.head_ref.name}: lacks a required label")
-      @@logger.info("   PR Labels: #{pr_labels.join(', ')}")
-      @@logger.info("   Required labels: #{require_labels.join(', ')}")
+      @logger.info("-- Rejecting #{pull_request.node.head_ref.name}: lacks a required label")
+      @logger.info("   PR Labels: #{pr_labels.join(', ')}")
+      @logger.info("   Required labels: #{require_labels.join(', ')}")
       return false
     end
     true
@@ -189,15 +208,17 @@ module GitHub
 
   def self.pr_has_at_least_one_label?(pull_request, pr_labels, at_least_one_label)
     if !at_least_one_label.empty? && (pr_labels & at_least_one_label == [])
-      @@logger.info("-- Rejecting #{pull_request.node.head_ref.name}: lacks at least one label")
-      @@logger.info("   PR Labels: #{pr_labels.join(', ')}")
-      @@logger.info("   At least one label: #{at_least_one_label.join(', ')}")
+      @logger.info("-- Rejecting #{pull_request.node.head_ref.name}: lacks at least one label")
+      @logger.info("   PR Labels: #{pr_labels.join(', ')}")
+      @logger.info("   At least one label: #{at_least_one_label.join(', ')}")
       return false
     end
     true
   end
 
   def self.branches_matching_filter(opts)
+    @count = 0
+    @unknowns = 0
     result = GitHub::Client.query(GitHub::FirstQuery)
     good_prs = GitHub.pr_filter(
       result,
@@ -208,10 +229,17 @@ module GitHub
     )
     while result.data.repository.pull_requests.page_info.has_next_page?
       cursor = result.data.repository.pull_requests.page_info.end_cursor
-      @@logger.debug("Next Page: #{cursor}")
+      @logger.debug("Next Page: #{cursor}")
       result = GitHub::Client.query(GitHub::NextQuery, variables: { cursor: cursor })
-      good_prs += GitHub.pr_filter(result, base, reject_labels, require_labels, at_least_one_label)
+      good_prs += GitHub.pr_filter(
+        result,
+        opts[:base],
+        opts[:reject_labels],
+        opts[:require_labels],
+        opts[:at_least_one_label]
+      )
     end
+    @tries += 1
     good_prs
   end
 end


### PR DESCRIPTION
When you make a change to a branch, especially the target branch, all branches' merge states become UNKNOWN. This usually resolves itself quickly. This version now retries with a delay in this case.